### PR TITLE
Fixed bug where clock speed slider jumps back and forth

### DIFF
--- a/index.js
+++ b/index.js
@@ -355,7 +355,9 @@ function run() {
 		return;
 	}
 	let clockSpeed = clockSlider.value;
-	clockNumber.textContent = 'Clock Speed: ' + clockSpeed;
+	// pad end with non-breaking space so that slider doesn't move back and
+	// forth as number of digits changes
+	clockNumber.textContent = 'Clock Speed: ' + String(clockSpeed).padEnd(3, '\xa0');
 	while (performance.now() - time >= 1000 / clockSpeed) {
 		time += 1000 / clockSpeed;
 		const instruction = binaryMap[ram[programCounter.value]];


### PR DESCRIPTION
Morning!

I've just fixed a tiny bug where the clock speed slider jumps left and right as the number of digits in the clock speed changes. This version pads the end of the span showing the clock speed with spaces so that its length is always the same.

I don't know if it's of any use, it's only a small thing.

Anyway, keep it up, it's a really interesting project! I'm looking forward to seeing the computer in action.