### PR TITLE
Added basic comments and labels functionality

### DIFF
--- a/index.js
+++ b/index.js
@@ -188,7 +188,9 @@ const binaryMap = [
 
 //
 function textToCode() {
-	const words = codeEditor.value.replaceAll('\n', ' ').split(' ');
+	let commentFree = codeEditor.value.replace(/;.*/g, ""); //remove text from semicolon to end of line
+	let words = commentFree.replaceAll('\n', ' ').split(' ');
+	words = words.filter((word) => word !== ""); //remove blank words (from lines with just a comment)
 	words.forEach((w, i) => {
 		let v = binaryMap.indexOf(NOP);
 		switch (w) {

--- a/index.js
+++ b/index.js
@@ -191,6 +191,7 @@ function textToCode() {
 	let commentFree = codeEditor.value.replace(/;.*/g, ""); //remove text from semicolon to end of line
 	let words = commentFree.replaceAll('\n', ' ').split(' ');
 	words = words.filter((word) => word !== ""); //remove blank words (from lines with just a comment)
+	words = processLabels(words);
 	words.forEach((w, i) => {
 		let v = binaryMap.indexOf(NOP);
 		switch (w) {
@@ -217,6 +218,34 @@ function textToCode() {
 	});
 	disBinary.value = codeToBinary();
 	disOctal.value = codeToOctal();
+}
+
+// Remove the label declarations (ending with a colon) from the words of
+// the program and store the addresses they refer to in a symbol table.
+// Then replace references to these labels with the addresses.
+function processLabels(words) {
+	let symbolTable = {}; //symbol table to hold labels and their addresses
+	let addressCount = 0;
+	let wordsWithoutLabelDeclarations = [];
+	//first pass: find label declarations and add them to symbol table
+	for (let word of words) {
+		if (word.endsWith(":")) { //if word is a label declaration add current address count to symbol table
+			symbolTable[word.slice(0, -1)] = String(addressCount);
+		} else { //othewise increment address counter and add word to new words list
+			addressCount++;
+			wordsWithoutLabelDeclarations.push(word);
+		}
+	}
+	let wordsWithoutLabels = [];
+	//second pass: replace references to labels with their addresses from symbol table
+	for (let word of wordsWithoutLabelDeclarations) {
+		if (word in symbolTable) { //if word is a label in the symbol table
+			wordsWithoutLabels.push(symbolTable[word]); //replace it with address
+		} else { //otherwise just push the word as it is
+			wordsWithoutLabels.push(word);
+		}
+	}
+	return wordsWithoutLabels; //return list of words with labels replaced by addresses
 }
 
 //


### PR DESCRIPTION
Hi!

I've added the ability to use comments and labels with the simulator.

Comments come after a semicolon. For example, this version of the addition program results in the same instructions being placed in RAM as the original without comments:

```asm
;program to add two numbers

LDA 6 ;load first term into accumulator
ADD 7 ;add second term
OUT   ;write value in accumulator to output register
HLT   ;halt
;terms to be added:
4
7
```

Label declarations are followed by a colon. Other references to the label in the program are then replaced with the address the label declaration appeared at. For example, here's a modified version of the multiplication program which assembles to exactly the same instructions as the original:

```asm
  LDA NUM1
  STA 34
  LDA NUM2
  STA 33
LOOP:
  LDA 33
  JIZ OUTPUT
  LDA 34
  ADD 31
  STA 34
  LDA 33
  SEB 1
  SBR
  STA 33
  JMP LOOP
OUTPUT:
  LDA 34
  OUT
  HLT

NUM1: 5
NUM2: 10
```

Labels can be any combination of upper/lowercase characters, numbers and symbols except for ; (comment) and spaces and are case sensitive.

Hopefully some of this is useful!